### PR TITLE
InfluxDB UDP connection fix

### DIFF
--- a/src/MetricsServiceProvider.php
+++ b/src/MetricsServiceProvider.php
@@ -118,7 +118,7 @@ class MetricsServiceProvider extends ServiceProvider
             )
         );
 
-        $udpConnection = array_has($config, 'udp_port')
+        $udpConnection = (array_has($config, 'udp_port') && !empty($config['udp_port']))
             ? Client::fromDSN(sprintf('udp+influxdb://%s:%s@%s:%s/%s',
                 $config['username'],
                 $config['password'],


### PR DESCRIPTION
I'm faced with two problems. The first one is `Undefined index: port` exception. I fixed it by adding default port in `\InfluxDB\Client`. The second one is metrics are not saved in InfluxDB and influx daemon console keeps silence. After long hours of debugging I found out the problem: `\InfluxDB\Client` sets driver to UDP (289 line):
```php
if ($modifier == 'udp') {
    $client->setDriver(new UDP($connParams['host'], $connParams['port']));
}
```
This happens because `MetricsServiceProvider createInfluxDBDriver` call `Client::fromDSN` with UDP url because `array_has($config, 'udp_port')` is always true even if i did not set `IDB_UDP_PORT` and `$config['udp_port'] === null`. So check for emptiness is required.