### PR TITLE
Do not filter out zero values

### DIFF
--- a/src/Drivers/CloudWatch.php
+++ b/src/Drivers/CloudWatch.php
@@ -89,14 +89,17 @@ class CloudWatch extends AbstractDriver
      */
     public function format(Metric $metric)
     {
-        return array_filter([
-            'MetricName'        => $metric->getName(),
-            'Dimensions'        => array_merge($this->tags, $metric->getTags()),
-            'StorageResolution' => in_array($metric->getResolution(), [1, 60]) ? $metric->getResolution() : null,
-            'Timestamp'         => $this->formatTimestamp($metric->getTimestamp()),
-            'Unit'              => $metric->getUnit(),
-            'Value'             => $metric->getValue()
-        ]);
+        return array_merge(
+            array_filter([
+                'MetricName'        => $metric->getName(),
+                'Dimensions'        => array_merge($this->tags, $metric->getTags()),
+                'StorageResolution' => in_array($metric->getResolution(), [1, 60]) ? $metric->getResolution() : null,
+                'Timestamp'         => $this->formatTimestamp($metric->getTimestamp()),
+                'Unit'              => $metric->getUnit()
+            ]), 
+            [
+                'Value'             => $metric->getValue()
+            ]);
     }
 
     /**


### PR DESCRIPTION
For CloudWatch, 0 is a valid value but array_filter removes it as being falsey and this causes an exception from AWS:

`<ErrorResponse xmlns=\"http://monitoring.amazonaws.com/doc/2010-08-01/\">
  <Error>
    <Type>Sender</Type>
    <Code>InvalidParameterCombination</Code>
    <Message>At least one of the parameters must be specified.
At least one of the parameters must be specified.</Message>
  </Error>
</ErrorResponse>`

I modified format to *always* include value, unfiltered.