### PR TITLE
Don't specify CloudWatch credentials if not configured

### DIFF
--- a/src/MetricsServiceProvider.php
+++ b/src/MetricsServiceProvider.php
@@ -142,15 +142,22 @@ class MetricsServiceProvider extends ServiceProvider
      */
     protected function createCloudWatchDriver(array $config)
     {
-        return new CloudWatch(
-            new CloudWatchClient([
-                'region'      => Arr::get($config, 'region'),
-                'version'     => '2010-08-01',
-                'credentials' => [
-                    'key'    => Arr::get($config, 'key'),
-                    'secret' => Arr::get($config, 'secret')
-                ]
-            ]), $config['namespace']
-        );
+        $opts = [
+            'region'  => Arr::get($config, 'region'),
+            'version' => '2010-08-01',
+        ];
+
+        // Add credentials if they've been defined, else fallback to loading
+        // credentials from the environment.
+        $key = Arr::get($config, 'key');
+        $secret = Arr::get($config, 'secret');
+        if ($key !== null && $secret !== null) {
+            $opts['credentials'] = [
+                'key'    => $key,
+                'secret' => $secret,
+            ];
+        }
+
+        return new CloudWatch(new CloudWatchClient($opts), $config['namespace']);
     }
 }


### PR DESCRIPTION
Hey there,

This should allow the use of other credential providers, not just an access key / secret combo as a set of environment variables.

As an example - a number of our production-like environments don't hardcode AWS credentials anywhere and instead load them via instance profiles or roles. The underlying AWS SDK already has support for this, as long as a `credentials` block isn't specified when configuring the client.

There's some detail about what happens here: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html

This change removes the `credentials` block and only specifies it if an access key & secret are configured.