### PR TITLE
Add FlushMetrics octane listener

### DIFF
--- a/src/MetricsServiceProvider.php
+++ b/src/MetricsServiceProvider.php
@@ -3,7 +3,6 @@
 namespace STS\Metrics;
 
 use Aws\CloudWatch\CloudWatchClient;
-use Aws\Sdk;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use InfluxDB\Client;
@@ -12,6 +11,7 @@ use STS\Metrics\Drivers\CloudWatch;
 use STS\Metrics\Drivers\InfluxDB;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Laravel\Lumen\Application as LumenApplication;
+use STS\Metrics\Octane\Listeners\FlushMetrics;
 
 /**
  * Class MetricsServiceProvider
@@ -86,6 +86,10 @@ class MetricsServiceProvider extends ServiceProvider
                     ->add($event->createMetric());
             }
         });
+
+        if (class_exists(\Laravel\Octane\Events\RequestTerminated::class)) {
+            $this->app['events']->listen(\Laravel\Octane\Events\RequestTerminated::class, FlushMetrics::class);
+        }
     }
 
     /**

--- a/src/Octane/Listeners/FlushMetrics.php
+++ b/src/Octane/Listeners/FlushMetrics.php
@@ -6,7 +6,7 @@ class FlushMetrics
 {
     public function handle($event)
     {
-        $metrics = app('metrcis');
+        $metrics = app('metrics');
 
         foreach ($metrics->getDrivers() as $driver) {
             $driver->flush();

--- a/src/Octane/Listeners/FlushMetrics.php
+++ b/src/Octane/Listeners/FlushMetrics.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace STS\Metrics\Octane\Listeners;
+
+class FlushMetrics
+{
+    public function handle($event)
+    {
+        $metrics = app('metrcis');
+
+        foreach ($metrics->getDrivers() as $driver) {
+            $driver->flush();
+        }
+    }
+}


### PR DESCRIPTION
The FlushMetrics listener may be used with Laravel Octanes **RequestTerminated** event which emulates the same functionality that **register_shutdown_function** provides when PHP-FPM or mod_php