### PR TITLE
Avoid warnings on ComputesNanosecondTimestamps

### DIFF
--- a/src/Traits/ComputesNanosecondTimestamps.php
+++ b/src/Traits/ComputesNanosecondTimestamps.php
@@ -42,7 +42,7 @@ trait ComputesNanosecondTimestamps
                 };
             }
         } elseif (is_float($timestamp)) {
-            $integerLength = strlen((string)(int) $timestamp);
+            $integerLength = (int) floor(log10(abs($timestamp))) + 1;
 
             return match ($integerLength) {
                 // Looks like it is already nanosecond precise!

--- a/src/Traits/ComputesNanosecondTimestamps.php
+++ b/src/Traits/ComputesNanosecondTimestamps.php
@@ -17,6 +17,10 @@ trait ComputesNanosecondTimestamps
             return $timestamp->getTimestamp() * 1000000000;
         }
 
+        if (is_null($timestamp) || (is_string($timestamp) && strlen($timestamp) < 10)) {
+           return $this->generateTimestamp();
+        }
+
         if (strlen($timestamp) == 19) {
             // Looks like it is already nanosecond precise!
             return $timestamp;
@@ -33,6 +37,14 @@ trait ComputesNanosecondTimestamps
         }
 
         // We weren't given a valid timestamp, generate.
+        return $this->generateTimestamp();
+    }
+
+    /**
+     * @return int
+     */
+    protected function generateTimestamp(): int
+    {
         return (int)(microtime(true) * 1000000000);
     }
 }

--- a/src/Traits/ComputesNanosecondTimestamps.php
+++ b/src/Traits/ComputesNanosecondTimestamps.php
@@ -17,21 +17,23 @@ trait ComputesNanosecondTimestamps
             return $timestamp->getTimestamp() * 1000000000;
         }
 
-        if (is_null($timestamp) || (is_string($timestamp) && strlen($timestamp) < 10)) {
+        $length = is_string($timestamp) ? strlen($timestamp) : 0;
+
+        if (is_null($timestamp) || $length < 10) {
            return $this->generateTimestamp();
         }
 
-        if (strlen($timestamp) == 19) {
+        if ($length === 19) {
             // Looks like it is already nanosecond precise!
             return $timestamp;
         }
 
-        if (strlen($timestamp) == 10) {
+        if ($length === 10) {
             // This appears to be in seconds
             return $timestamp * 1000000000;
         }
 
-        if (preg_match("/\d{10}\.\d{4}/", $timestamp)) {
+        if (preg_match("/\d{10}\.\d{1,4}$/", $timestamp)) {
             // This looks like a microtime float
             return (int)($timestamp * 1000000000);
         }

--- a/src/Traits/ComputesNanosecondTimestamps.php
+++ b/src/Traits/ComputesNanosecondTimestamps.php
@@ -4,6 +4,8 @@ namespace STS\Metrics\Traits;
 
 trait ComputesNanosecondTimestamps
 {
+    protected const TO_NANO = 1000000000;
+
     /**
      * A public way tog et the nanosecond precision we desire.
      *
@@ -14,28 +16,41 @@ trait ComputesNanosecondTimestamps
     public function getNanoSecondTimestamp($timestamp = null)
     {
         if ($timestamp instanceof \DateTime) {
-            return $timestamp->getTimestamp() * 1000000000;
-        }
+            return $timestamp->getTimestamp() * self::TO_NANO;
+        } elseif (is_int($timestamp)) {
+            $length = strlen((string) $timestamp);
 
-        $length = is_string($timestamp) ? strlen($timestamp) : 0;
+            return match ($length) {
+                // Looks like it is already nanosecond precise!
+                19 => $timestamp,
+                // This appears to be in seconds
+                10 => $timestamp * self::TO_NANO,
+                default => $this->generateTimestamp(),
+            };
+        } elseif (is_string($timestamp)) {
+            if (preg_match("/\d{10}\.\d{1,4}$/", $timestamp)) {
+                return (int) ($timestamp * self::TO_NANO);
+            } elseif (ctype_digit($timestamp)) {
+                $length = strlen($timestamp);
 
-        if (is_null($timestamp) || $length < 10) {
-           return $this->generateTimestamp();
-        }
+                return match ($length) {
+                    // Looks like it is already nanosecond precise!
+                    19 => (int) $timestamp,
+                    // This appears to be in seconds
+                    10 => (int) ($timestamp * self::TO_NANO),
+                    default => $this->generateTimestamp(),
+                };
+            }
+        } elseif (is_float($timestamp)) {
+            $integerLength = strlen((string)(int) $timestamp);
 
-        if ($length === 19) {
-            // Looks like it is already nanosecond precise!
-            return $timestamp;
-        }
-
-        if ($length === 10) {
-            // This appears to be in seconds
-            return $timestamp * 1000000000;
-        }
-
-        if (preg_match("/\d{10}\.\d{1,4}$/", $timestamp)) {
-            // This looks like a microtime float
-            return (int)($timestamp * 1000000000);
+            return match ($integerLength) {
+                // Looks like it is already nanosecond precise!
+                19 => (int) $timestamp,
+                // This appears to be in seconds
+                10 => (int) ($timestamp * self::TO_NANO),
+                default => $this->generateTimestamp(),
+            };
         }
 
         // We weren't given a valid timestamp, generate.
@@ -47,6 +62,6 @@ trait ComputesNanosecondTimestamps
      */
     protected function generateTimestamp(): int
     {
-        return (int)(microtime(true) * 1000000000);
+        return (int) (microtime(true) * self::TO_NANO);
     }
 }

--- a/tests/InfluxDBV2DriverTest.php
+++ b/tests/InfluxDBV2DriverTest.php
@@ -99,6 +99,10 @@ class InfluxDBV2DriverTest extends TestCase
             [15087137281,], // 11 digits
             [150871372,], // 9 digits
             [15087137,], // 8 digits
+            [0,],
+            [0.0,],
+            ['000000000.1',],
+            ['000000000.0',],
         ];
     }
 }


### PR DESCRIPTION
Fixes the following warnings:

```
strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /vendor/stechstudio/laravel-metrics/src/Traits/ComputesNanosecondTimestamps.php on line 29
strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /vendor/stechstudio/laravel-metrics/src/Traits/ComputesNanosecondTimestamps.php on line 24
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /vendor/stechstudio/laravel-metrics/src/Traits/ComputesNanosecondTimestamps.php on line 34
```