### PR TITLE
Move session ID hash into getAnonymousId

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,11 +276,10 @@ The closure will be called fresh each time a metric is formatted. This also work
 
 ## User ID resolution
 
-Drivers automatically resolve the current user ID using the following strategy:
+Drivers automatically resolve the current user ID via `getUserId()`:
 
 1. If a user is authenticated: `auth()->id()`
-2. If a session is active: a hashed session ID
-3. Otherwise: a random string (stable for the lifetime of the process)
+2. Otherwise: `getAnonymousId()`, which returns a hashed session ID if a session is active, or a random string (stable for the lifetime of the process)
 
 This is used by the PostHog driver as the `distinctId`, and is available to any driver via `$driver->getUserId()`.
 

--- a/src/Drivers/AbstractDriver.php
+++ b/src/Drivers/AbstractDriver.php
@@ -79,15 +79,17 @@ abstract class AbstractDriver
             return call_user_func($this->userIdResolver, $this);
         }
 
-        return match(true) {
-            auth()->check() => auth()->id(),
-            session()->isStarted() => sha1(session()->getId()),
-            default => $this->getAnonymousId()
-        };
+        return auth()->check()
+            ? auth()->id()
+            : $this->getAnonymousId();
     }
 
     public function getAnonymousId(): string
     {
+        if (session()->isStarted()) {
+            return sha1(session()->getId());
+        }
+
         static $anonymousId = null;
 
         return $anonymousId ??= Str::random();


### PR DESCRIPTION
## Summary
- Moves the session ID hash from `getUserId()` into `getAnonymousId()`
- Session-based users are anonymous (not authenticated), so this is the correct home for that logic
- `getUserId()` now simply returns `auth()->id()` or `getAnonymousId()`
- `getAnonymousId()` returns hashed session ID if available, otherwise a stable random string
- Updates README to reflect the change